### PR TITLE
Fix compilation on Mac OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ include mshadow/make/mshadow.mk
 # all tge possible warning tread
 WARNFLAGS= -Wall
 CFLAGS = -DNOT_IN_MATLAB -DMSHADOW_FORCE_STREAM $(WARNFLAGS)
-CFLAGS += -g -O3 -I./mshadow/  -fopenmp -fPIC $(MSHADOW_CFLAGS)
+CFLAGS += -g -O3 -I./mshadow/ -fPIC $(MSHADOW_CFLAGS)
 LDFLAGS = -lz -pthread $(MSHADOW_LDFLAGS)
 NVCCFLAGS = --use_fast_math -g -O3 -ccbin $(CXX) $(MSHADOW_NVCCFLAGS)
 

--- a/src/io/iter_thread_imbin_x-inl.hpp
+++ b/src/io/iter_thread_imbin_x-inl.hpp
@@ -7,7 +7,6 @@
  */
 #include "data.h"
 #include <cstdlib>
-#include <omp.h>
 #include "../utils/thread_buffer.h"
 #include "../utils/utils.h"
 #include "../utils/decoder.h"

--- a/src/updater/sgd_updater-inl.hpp
+++ b/src/updater/sgd_updater-inl.hpp
@@ -6,7 +6,7 @@
  * \author Tianqi Chen
  */
 #include <mshadow/tensor.h>
- #include "./updater.h"
+#include "./updater.h"
 #include "./param.h"
 
 namespace cxxnet {


### PR DESCRIPTION
With these patches, `cxxnet` compiles and works well on my Yosemite laptop.