### PR TITLE
Use check than return false when parsing the config files.

### DIFF
--- a/src/utils/config.h
+++ b/src/utils/config.h
@@ -40,9 +40,11 @@ class ConfigReaderBase {
   inline bool Next(void) {
     while (!this->IsEnd()) {
       GetNextToken(&s_name);
-      if (s_name == "=") return false;
-      if (GetNextToken(&s_buf) || s_buf != "=")  return false;
-      if (GetNextToken(&s_val) || s_val == "=")  return false;
+      utils::Check(s_name != "=", "Invalid '=' in config file.");
+      utils::Check((!GetNextToken(&s_buf) && s_buf == "="),
+                   "Invalid str:%s in config file.", s_buf.c_str());
+      utils::Check((!GetNextToken(&s_val) && s_val != "="),
+                   "Invalid str:%s in config file.", s_val.c_str());
       return true;
     }
     return false;


### PR DESCRIPTION
Hi:
     Happy to propose a code change. The motivation to modified the config.h is from my own use case.
     When I wrote a config file for adding a conv layer, I used a chinese charater '=' instead of ascii '=' by accident, which was really hard to notice.
     So the run.sh give a weird error msg like "kernel size exceed input error", I spend a lots of time to figure out why the kernel size exceed. And I found the config was using a chinese charater '=', which cause the config parse skip the all configs content followed the invalid string.  
     I think generally the parser should check the invalid config file instead of just skip it. It's more clear for user, not like me spend a lot of time to debug the tool for reasoning unmatched error message.