### PR TITLE
fix link error for python wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ data.o: src/io/data.cpp src/io/*.hpp
 
 main.o: src/cxxnet_main.cpp
 
-wrapper/libcxxnetwrapper.so: wrapper/cxxnet_wrapper.cpp $(OBJCXX11) $(LIB_DEP) $(CUDEP)
+wrapper/libcxxnetwrapper.so: wrapper/cxxnet_wrapper.cpp $(OBJ) $(OBJCXX11) $(LIB_DEP) $(CUDEP)
 bin/cxxnet: src/local_main.cpp $(OBJ) $(OBJCXX11) $(LIB_DEP) $(CUDEP)
 bin/cxxnet.ps: $(OBJ) $(OBJCXX11) $(CUDEP) $(LIB_DEP) $(PS_LIB)
 bin/im2rec: tools/im2rec.cc $(DMLC_CORE)/libdmlc.a


### PR DESCRIPTION
wrapper/libcxxnetwrapper.so: undefined symbol: _ZN7mshadow2ps18CreateModelUpdaterIfEEPNS0_13IModelUpdaterIT_EEv