### PR TITLE
Build with as many cores as there are on the system.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,5 +18,8 @@ if [ ! -f config.mk ]; then
     cp make/config.mk config.mk
 fi
 
-make -j4
+# Use as many CPUs as the host has to build, or default to
+# 4 if we're not on a unix-y system.
+num_cpus=$(grep -sc ^processor /proc/cpuinfo || echo 4)
+make -j$num_cpus
 

--- a/build_ps.sh
+++ b/build_ps.sh
@@ -28,5 +28,7 @@ fi
 sed -i 's/USE_DIST_PS.*/USE_DIST_PS = 1/' config.mk
 sed -i 's/PS_PATH.*/PS_PATH = .\/ps-lite/' config.mk
 
-make -j4
-# make $1
+# Use as many CPUs as the host has to build, or default to
+# 4 if we're not on a unix-y system.
+num_cpus=$(grep -sc ^processor /proc/cpuinfo || echo 4)
+make -j$num_cpus


### PR DESCRIPTION
On unix-like systems where we can use /proc/cpuinfo to find the
number of cores, use all of them when building, rather than only
using 4.

Still default to 4 when we don't have /proc/cpuinfo. Apparently
you can use $(sysctl -a | grep machdep.cpu | grep thread_count)
on Mac, but I don't have one available to try.